### PR TITLE
Update docs to fix incorrect tag for JS tests

### DIFF
--- a/tests/behat/behat.common.yml
+++ b/tests/behat/behat.common.yml
@@ -18,7 +18,7 @@ default:
       # Use goutte (basic PHP browser, super fast) as the default driver.
       default_session: goutte
       # For real browser testing and tests requiring JS use selenium2 driver.
-      # Tag features/scenarious with @javascript to use the selenium2 driver.
+      # Tag features/scenarious with @js to use the selenium2 driver.
       javascript_session: selenium2
     Drupal\DrupalExtension:
       blackbox: ~


### PR DESCRIPTION
Fix incorrect documentation about running tests with javascript.