### PR TITLE
Drupal 7.61

### DIFF
--- a/.docksal/docksal.yml
+++ b/.docksal/docksal.yml
@@ -70,9 +70,7 @@ services:
   # Browser
   browser:
     hostname: browser
-    image: selenium/standalone-chrome-debug
-    ports:
-      - "5900:5900"
+    image: selenium/standalone-chrome
     dns:
       - ${DOCKSAL_DNS1}
       - ${DOCKSAL_DNS2}

--- a/docroot/CHANGELOG.txt
+++ b/docroot/CHANGELOG.txt
@@ -1,3 +1,20 @@
+Drupal 7.61, 2018-11-07
+-----------------------
+- File upload validation functions and hook_file_validate() implementations are
+  now always passed the correct file URI.
+- The default form cache expiration of 6 hours is now configurable (API
+  addition: https://www.drupal.org/node/2857751).
+- Allowed callers of drupal_http_request() to optionally specify an explicit
+  Host header.
+- Allowed the + character to appear in usernames.
+- PHP 7.2: Fixed Archive_Tar incompatibility.
+- PHP 7.2: Removed deprecated function each().
+- PHP 7.2: Avoid count() calls on uncountable variables.
+- PHP 7.2: Removed deprecated create_function() call.
+- PHP 7.2: Make sure variables are arrays in theme_links().
+- Fixed theme-settings.php not being loaded on cached forms
+- Fixed problem with IE11 & Chrome(PointerEvents enabled) & some Firefox scroll to the top of the page after dragging the bottom item with jquery 1.5 <-> 1.11
+
 Drupal 7.60, 2018-10-18
 ------------------------
 - Fixed security issues. See SA-CORE-2018-006.
@@ -8,7 +25,7 @@ Drupal 7.59, 2018-04-25
 
 Drupal 7.58, 2018-03-28
 -----------------------
-- Fixed security issues (multiple vulnerabilities). See SA-CORE-2018-002.
+- Fixed security issues (remote code execution). See SA-CORE-2018-002.
 
 Drupal 7.57, 2018-02-21
 -----------------------

--- a/docroot/MAINTAINERS.txt
+++ b/docroot/MAINTAINERS.txt
@@ -15,6 +15,7 @@ The branch maintainers for Drupal 7 are:
 - Fabian Franz 'Fabianx' https://www.drupal.org/u/fabianx
 - David Rothstein 'David_Rothstein' https://www.drupal.org/u/david_rothstein
 - Stefan Ruijsenaars 'stefan.r' https://www.drupal.org/u/stefanr-0
+- (provisional) Pol Dellaiera 'Pol' https://www.drupal.org/u/pol
 
 
 Component maintainers
@@ -44,10 +45,9 @@ Cron system
 - Derek Wright 'dww' https://www.drupal.org/u/dww
 
 Database system
-- Larry Garfield 'Crell' https://www.drupal.org/u/crell
+- ?
 
   - MySQL driver
-    - Larry Garfield 'Crell' https://www.drupal.org/u/crell
     - David Strauss 'David Strauss' https://www.drupal.org/u/david-strauss
 
   - PostgreSQL driver

--- a/docroot/includes/bootstrap.inc
+++ b/docroot/includes/bootstrap.inc
@@ -8,7 +8,7 @@
 /**
  * The current system version.
  */
-define('VERSION', '7.60');
+define('VERSION', '7.61');
 
 /**
  * Core API compatibility.
@@ -3785,8 +3785,12 @@ function _drupal_shutdown_function() {
   chdir(DRUPAL_ROOT);
 
   try {
-    while (list($key, $callback) = each($callbacks)) {
+    // Manually iterate over the array instead of using a foreach loop.
+    // A foreach operates on a copy of the array, so any shutdown functions that
+    // were added from other shutdown functions would never be called.
+    while ($callback = current($callbacks)) {
       call_user_func_array($callback['callback'], $callback['arguments']);
+      next($callbacks);
     }
   }
   catch (Exception $exception) {

--- a/docroot/includes/common.inc
+++ b/docroot/includes/common.inc
@@ -867,8 +867,10 @@ function drupal_http_request($url, array $options = array()) {
       // Make the socket connection to a proxy server.
       $socket = 'tcp://' . $proxy_server . ':' . variable_get('proxy_port', 8080);
       // The Host header still needs to match the real request.
-      $options['headers']['Host'] = $uri['host'];
-      $options['headers']['Host'] .= isset($uri['port']) && $uri['port'] != 80 ? ':' . $uri['port'] : '';
+      if (!isset($options['headers']['Host'])) {
+        $options['headers']['Host'] = $uri['host'];
+        $options['headers']['Host'] .= isset($uri['port']) && $uri['port'] != 80 ? ':' . $uri['port'] : '';
+      }
       break;
 
     case 'http':
@@ -878,14 +880,18 @@ function drupal_http_request($url, array $options = array()) {
       // RFC 2616: "non-standard ports MUST, default ports MAY be included".
       // We don't add the standard port to prevent from breaking rewrite rules
       // checking the host that do not take into account the port number.
-      $options['headers']['Host'] = $uri['host'] . ($port != 80 ? ':' . $port : '');
+      if (!isset($options['headers']['Host'])) {
+        $options['headers']['Host'] = $uri['host'] . ($port != 80 ? ':' . $port : '');
+      }
       break;
 
     case 'https':
       // Note: Only works when PHP is compiled with OpenSSL support.
       $port = isset($uri['port']) ? $uri['port'] : 443;
       $socket = 'ssl://' . $uri['host'] . ':' . $port;
-      $options['headers']['Host'] = $uri['host'] . ($port != 443 ? ':' . $port : '');
+      if (!isset($options['headers']['Host'])) {
+        $options['headers']['Host'] = $uri['host'] . ($port != 443 ? ':' . $port : '');
+      }
       break;
 
     default:

--- a/docroot/includes/file.inc
+++ b/docroot/includes/file.inc
@@ -1536,7 +1536,7 @@ function file_save_upload($form_field_name, $validators = array(), $destination 
   // evaluates to TRUE.
   if (!variable_get('allow_insecure_uploads', 0) && preg_match('/\.(php|pl|py|cgi|asp|js)(\.|$)/i', $file->filename) && (substr($file->filename, -4) != '.txt')) {
     $file->filemime = 'text/plain';
-    $file->uri .= '.txt';
+    // The destination filename will also later be used to create the URI.
     $file->filename .= '.txt';
     // The .txt extension may not be in the allowed list of extensions. We have
     // to add it here or else the file upload will fail.

--- a/docroot/includes/form.inc
+++ b/docroot/includes/form.inc
@@ -555,8 +555,10 @@ function form_get_cache($form_build_id, &$form_state) {
  * Stores a form in the cache.
  */
 function form_set_cache($form_build_id, $form, $form_state) {
-  // 6 hours cache life time for forms should be plenty.
-  $expire = 21600;
+  // The default cache_form expiration is 6 hours. On busy sites, the cache_form
+  // table can become very large. A shorter cache lifetime can help to keep the
+  // table's size under control.
+  $expire = variable_get('form_cache_expiration', 21600);
 
   // Ensure that the form build_id embedded in the form structure is the same as
   // the one passed in as a parameter. This is an additional safety measure to
@@ -1438,10 +1440,12 @@ function _form_validate(&$elements, &$form_state, $form_id = NULL) {
       // length if it's a string, and the item count if it's an array.
       // An unchecked checkbox has a #value of integer 0, different than string
       // '0', which could be a valid value.
-      $is_empty_multiple = (!count($elements['#value']));
+      $is_countable = is_array($elements['#value']) || $elements['#value'] instanceof Countable;
+      $is_empty_multiple = $is_countable && count($elements['#value']) == 0;
       $is_empty_string = (is_string($elements['#value']) && drupal_strlen(trim($elements['#value'])) == 0);
       $is_empty_value = ($elements['#value'] === 0);
-      if ($is_empty_multiple || $is_empty_string || $is_empty_value) {
+      $is_empty_null = is_null($elements['#value']);
+      if ($is_empty_multiple || $is_empty_string || $is_empty_value || $is_empty_null) {
         // Although discouraged, a #title is not mandatory for form elements. In
         // case there is no #title, we cannot set a form error message.
         // Instead of setting no #title, form constructors are encouraged to set

--- a/docroot/includes/install.inc
+++ b/docroot/includes/install.inc
@@ -779,7 +779,7 @@ function drupal_uninstall_modules($module_list = array(), $uninstall_dependents 
     $module_list = array_flip(array_values($module_list));
 
     $profile = drupal_get_profile();
-    while (list($module) = each($module_list)) {
+    foreach (array_keys($module_list) as $module) {
       if (!isset($module_data[$module]) || drupal_get_installed_schema_version($module) == SCHEMA_UNINSTALLED) {
         // This module doesn't exist or is already uninstalled. Skip it.
         unset($module_list[$module]);

--- a/docroot/includes/menu.inc
+++ b/docroot/includes/menu.inc
@@ -576,7 +576,8 @@ function _menu_load_objects(&$item, &$map) {
           // 'load arguments' in the hook_menu() entry, but they need
           // some processing. In this case the $function is the key to the
           // load_function array, and the value is the list of arguments.
-          list($function, $args) = each($function);
+          $args = current($function);
+          $function = key($function);
           $load_functions[$index] = $function;
 
           // Some arguments are placeholders for dynamic items to process.
@@ -2402,7 +2403,8 @@ function menu_set_active_trail($new_trail = NULL) {
       // a stripped down menu tree containing the active trail only, in case
       // the given menu has not been built in this request yet.
       $tree = menu_tree_page_data($preferred_link['menu_name'], NULL, TRUE);
-      list($key, $curr) = each($tree);
+      $curr = current($tree);
+      next($tree);
     }
     // There is no link for the current path.
     else {
@@ -2432,7 +2434,8 @@ function menu_set_active_trail($new_trail = NULL) {
         }
         $tree = $curr['below'] ? $curr['below'] : array();
       }
-      list($key, $curr) = each($tree);
+      $curr = current($tree);
+      next($tree);
     }
     // Make sure the current page is in the trail to build the page title, by
     // appending either the preferred link or the menu router item for the

--- a/docroot/includes/module.inc
+++ b/docroot/includes/module.inc
@@ -404,7 +404,11 @@ function module_enable($module_list, $enable_dependencies = TRUE) {
     // Create an associative array with weights as values.
     $module_list = array_flip(array_values($module_list));
 
-    while (list($module) = each($module_list)) {
+    // The array is iterated over manually (instead of using a foreach) because
+    // modules may be added to the list within the loop and we need to process
+    // them.
+    while ($module = key($module_list)) {
+      next($module_list);
       if (!isset($module_data[$module])) {
         // This module is not found in the filesystem, abort.
         return FALSE;
@@ -540,7 +544,11 @@ function module_disable($module_list, $disable_dependents = TRUE) {
     $module_list = array_flip(array_values($module_list));
 
     $profile = drupal_get_profile();
-    while (list($module) = each($module_list)) {
+    // The array is iterated over manually (instead of using a foreach) because
+    // modules may be added to the list within the loop and we need to process
+    // them.
+    while ($module = key($module_list)) {
+      next($module_list);
       if (!isset($module_data[$module]) || !$module_data[$module]->status) {
         // This module doesn't exist or is already disabled, skip it.
         unset($module_list[$module]);

--- a/docroot/includes/theme.inc
+++ b/docroot/includes/theme.inc
@@ -1776,13 +1776,13 @@ function theme_link($variables) {
  *     http://www.w3.org/TR/WCAG-TECHS/H42.html for more information.
  */
 function theme_links($variables) {
-  $links = $variables['links'];
-  $attributes = $variables['attributes'];
+  $links = (array) $variables['links'];
+  $attributes = (array) $variables['attributes'];
   $heading = $variables['heading'];
   global $language_url;
   $output = '';
 
-  if (count($links) > 0) {
+  if (!empty($links)) {
     // Treat the heading first if it is present to prepend it to the
     // list of links.
     if (!empty($heading)) {
@@ -1995,7 +1995,7 @@ function theme_table($variables) {
   $empty = $variables['empty'];
 
   // Add sticky headers, if applicable.
-  if (count($header) && $sticky) {
+  if (!empty($header) && $sticky) {
     drupal_add_js('misc/tableheader.js');
     // Add 'sticky-enabled' class to the table to identify it for JS.
     // This is needed to target tables constructed by this function.
@@ -2009,7 +2009,7 @@ function theme_table($variables) {
   }
 
   // Format the table columns:
-  if (count($colgroups)) {
+  if (!empty($colgroups)) {
     foreach ($colgroups as $number => $colgroup) {
       $attributes = array();
 
@@ -2044,38 +2044,40 @@ function theme_table($variables) {
   }
 
   // Add the 'empty' row message if available.
-  if (!count($rows) && $empty) {
+  if (empty($rows) && $empty) {
     $header_count = 0;
-    foreach ($header as $header_cell) {
-      if (is_array($header_cell)) {
-        $header_count += isset($header_cell['colspan']) ? $header_cell['colspan'] : 1;
-      }
-      else {
-        $header_count++;
+    if (!empty($header)) {
+      foreach ($header as $header_cell) {
+        if (is_array($header_cell)) {
+          $header_count += isset($header_cell['colspan']) ? $header_cell['colspan'] : 1;
+        }
+        else {
+          $header_count++;
+        }
       }
     }
     $rows[] = array(array('data' => $empty, 'colspan' => $header_count, 'class' => array('empty', 'message')));
   }
 
   // Format the table header:
-  if (count($header)) {
+  if (!empty($header)) {
     $ts = tablesort_init($header);
     // HTML requires that the thead tag has tr tags in it followed by tbody
     // tags. Using ternary operator to check and see if we have any rows.
-    $output .= (count($rows) ? ' <thead><tr>' : ' <tr>');
+    $output .= (!empty($rows) ? ' <thead><tr>' : ' <tr>');
     foreach ($header as $cell) {
       $cell = tablesort_header($cell, $header, $ts);
       $output .= _theme_table_cell($cell, TRUE);
     }
     // Using ternary operator to close the tags based on whether or not there are rows
-    $output .= (count($rows) ? " </tr></thead>\n" : "</tr>\n");
+    $output .= (!empty($rows) ? " </tr></thead>\n" : "</tr>\n");
   }
   else {
     $ts = array();
   }
 
   // Format the table rows:
-  if (count($rows)) {
+  if (!empty($rows)) {
     $output .= "<tbody>\n";
     $flip = array('even' => 'odd', 'odd' => 'even');
     $class = 'even';
@@ -2095,7 +2097,7 @@ function theme_table($variables) {
         $attributes = array();
         $no_striping = FALSE;
       }
-      if (count($cells)) {
+      if (!empty($cells)) {
         // Add odd/even class
         if (!$no_striping) {
           $class = $flip[$class];

--- a/docroot/misc/tabledrag.js
+++ b/docroot/misc/tabledrag.js
@@ -580,21 +580,43 @@ Drupal.tableDrag.prototype.dropRow = function (event, self) {
  * Get the mouse coordinates from the event (allowing for browser differences).
  */
 Drupal.tableDrag.prototype.mouseCoords = function (event) {
-  // Complete support for pointer events was only introduced to jQuery in
-  // version 1.11.1; between versions 1.7 and 1.11.0 pointer events have the
-  // clientX and clientY properties undefined. In those cases, the properties
-  // must be retrieved from the event.originalEvent object instead.
-  var clientX = event.clientX || event.originalEvent.clientX;
-  var clientY = event.clientY || event.originalEvent.clientY;
 
-  if (event.pageX || event.pageY) {
-    return { x: event.pageX, y: event.pageY };
+  // Match both null and undefined, but not zero, by using != null.
+  // See https://stackoverflow.com/questions/2647867/how-to-determine-if-variable-is-undefined-or-null
+  if (event.pageX != null && event.pageY != null) {
+    return {x: event.pageX, y: event.pageY};
   }
 
-  return {
-    x: clientX + document.body.scrollLeft - document.body.clientLeft,
-    y: clientY + document.body.scrollTop  - document.body.clientTop
-  };
+  // Complete support for pointer events was only introduced to jQuery in
+  // version 1.11.1; between versions 1.7 and 1.11.0 pointer events have the
+  // pageX and pageY properties undefined. In those cases, the properties must
+  // be retrieved from the event.originalEvent object instead.
+  if (event.originalEvent && event.originalEvent.pageX != null && event.originalEvent.pageY != null) {
+    return {x: event.originalEvent.pageX, y: event.originalEvent.pageY};
+  }
+
+  // Some old browsers do not support MouseEvent.pageX and *.pageY at all.
+  // See https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/pageY
+  // For those, we look at event.clientX and event.clientY instead.
+  if (event.clientX == null || event.clientY == null) {
+    // In some jQuery versions, some events created by jQuery do not have
+    // clientX and clientY. But the original event might have.
+    if (!event.originalEvent) {
+      throw new Error("The event has no coordinates, and no event.originalEvent.");
+    }
+    event = event.originalEvent;
+    if (event.clientX == null || event.clientY == null) {
+      throw new Error("The original event has no coordinates.");
+    }
+  }
+
+  // Copied from jQuery.event.fix() in jQuery 1.4.1.
+  // In newer jQuery versions, this code is in jQuery.event.mouseHooks.filter().
+  var doc = document.documentElement, body = document.body;
+  var pageX = event.clientX + ( doc && doc.scrollLeft || body && body.scrollLeft || 0 ) - ( doc && doc.clientLeft || body && body.clientLeft || 0 );
+  var pageY = event.clientY + ( doc && doc.scrollTop  || body && body.scrollTop  || 0 ) - ( doc && doc.clientTop  || body && body.clientTop  || 0 );
+
+  return {x: pageX, y: pageY};
 };
 
 /**

--- a/docroot/modules/aggregator/aggregator.info
+++ b/docroot/modules/aggregator/aggregator.info
@@ -7,7 +7,7 @@ files[] = aggregator.test
 configure = admin/config/services/aggregator/settings
 stylesheets[all][] = aggregator.css
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/aggregator/tests/aggregator_test.info
+++ b/docroot/modules/aggregator/tests/aggregator_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/block/block.info
+++ b/docroot/modules/block/block.info
@@ -6,7 +6,7 @@ core = 7.x
 files[] = block.test
 configure = admin/structure/block
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/block/tests/block_test.info
+++ b/docroot/modules/block/tests/block_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/block/tests/themes/block_test_theme/block_test_theme.info
+++ b/docroot/modules/block/tests/themes/block_test_theme/block_test_theme.info
@@ -13,7 +13,7 @@ regions[footer] = Footer
 regions[highlighted] = Highlighted
 regions[help] = Help
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/blog/blog.info
+++ b/docroot/modules/blog/blog.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 files[] = blog.test
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/book/book.info
+++ b/docroot/modules/book/book.info
@@ -7,7 +7,7 @@ files[] = book.test
 configure = admin/content/book/settings
 stylesheets[all][] = book.css
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/book/book.module
+++ b/docroot/modules/book/book.module
@@ -768,11 +768,13 @@ function book_prev($book_link) {
     return NULL;
   }
   $flat = book_get_flat_menu($book_link);
-  // Assigning the array to $flat resets the array pointer for use with each().
+  reset($flat);
   $curr = NULL;
   do {
     $prev = $curr;
-    list($key, $curr) = each($flat);
+    $curr = current($flat);
+    $key = key($flat);
+    next($flat);
   } while ($key && $key != $book_link['mlid']);
 
   if ($key == $book_link['mlid']) {
@@ -806,9 +808,10 @@ function book_prev($book_link) {
  */
 function book_next($book_link) {
   $flat = book_get_flat_menu($book_link);
-  // Assigning the array to $flat resets the array pointer for use with each().
+  reset($flat);
   do {
-    list($key, $curr) = each($flat);
+    $key = key($flat);
+    next($flat);
   }
   while ($key && $key != $book_link['mlid']);
 

--- a/docroot/modules/color/color.info
+++ b/docroot/modules/color/color.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 files[] = color.test
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/comment/comment.info
+++ b/docroot/modules/comment/comment.info
@@ -9,7 +9,7 @@ files[] = comment.test
 configure = admin/content/comment
 stylesheets[all][] = comment.css
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/contact/contact.info
+++ b/docroot/modules/contact/contact.info
@@ -6,7 +6,7 @@ core = 7.x
 files[] = contact.test
 configure = admin/structure/contact
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/contextual/contextual.info
+++ b/docroot/modules/contextual/contextual.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 files[] = contextual.test
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/dashboard/dashboard.info
+++ b/docroot/modules/dashboard/dashboard.info
@@ -7,7 +7,7 @@ files[] = dashboard.test
 dependencies[] = block
 configure = admin/dashboard/customize
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/dblog/dblog.info
+++ b/docroot/modules/dblog/dblog.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 files[] = dblog.test
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/field/field.info
+++ b/docroot/modules/field/field.info
@@ -11,7 +11,7 @@ dependencies[] = field_sql_storage
 required = TRUE
 stylesheets[all][] = theme/field.css
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/field/modules/field_sql_storage/field_sql_storage.info
+++ b/docroot/modules/field/modules/field_sql_storage/field_sql_storage.info
@@ -7,7 +7,7 @@ dependencies[] = field
 files[] = field_sql_storage.test
 required = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/field/modules/list/list.info
+++ b/docroot/modules/field/modules/list/list.info
@@ -7,7 +7,7 @@ dependencies[] = field
 dependencies[] = options
 files[] = tests/list.test
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/field/modules/list/list.install
+++ b/docroot/modules/field/modules/list/list.install
@@ -61,7 +61,7 @@ function list_update_7001() {
 
       // Additionally, float keys need to be disambiguated ('.5' is '0.5').
       if ($field['type'] == 'list_number' && !empty($allowed_values)) {
-        $keys = array_map(create_function('$a', 'return (string) (float) $a;'), array_keys($allowed_values));
+        $keys = array_map('_list_update_7001_float_string_cast', array_keys($allowed_values));
         $allowed_values = array_combine($keys, array_values($allowed_values));
       }
 
@@ -86,6 +86,13 @@ function list_update_7001() {
         ->execute();
     }
   }
+}
+
+/**
+ * Helper callback function to cast the array element.
+ */
+function _list_update_7001_float_string_cast($element) {
+  return (string) (float) $element;
 }
 
 /**

--- a/docroot/modules/field/modules/list/tests/list_test.info
+++ b/docroot/modules/field/modules/list/tests/list_test.info
@@ -5,7 +5,7 @@ package = Testing
 version = VERSION
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/field/modules/number/number.info
+++ b/docroot/modules/field/modules/number/number.info
@@ -6,7 +6,7 @@ core = 7.x
 dependencies[] = field
 files[] = number.test
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/field/modules/options/options.info
+++ b/docroot/modules/field/modules/options/options.info
@@ -6,7 +6,7 @@ core = 7.x
 dependencies[] = field
 files[] = options.test
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/field/modules/text/text.info
+++ b/docroot/modules/field/modules/text/text.info
@@ -7,7 +7,7 @@ dependencies[] = field
 files[] = text.test
 required = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/field/tests/field_test.info
+++ b/docroot/modules/field/tests/field_test.info
@@ -6,7 +6,7 @@ files[] = field_test.entity.inc
 version = VERSION
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/field_ui/field_ui.info
+++ b/docroot/modules/field_ui/field_ui.info
@@ -6,7 +6,7 @@ core = 7.x
 dependencies[] = field
 files[] = field_ui.test
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/file/file.info
+++ b/docroot/modules/file/file.info
@@ -6,7 +6,7 @@ core = 7.x
 dependencies[] = field
 files[] = tests/file.test
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/file/tests/file_module_test.info
+++ b/docroot/modules/file/tests/file_module_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/filter/filter.info
+++ b/docroot/modules/filter/filter.info
@@ -7,7 +7,7 @@ files[] = filter.test
 required = TRUE
 configure = admin/config/content/formats
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/forum/forum.info
+++ b/docroot/modules/forum/forum.info
@@ -9,7 +9,7 @@ files[] = forum.test
 configure = admin/structure/forum
 stylesheets[all][] = forum.css
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/help/help.info
+++ b/docroot/modules/help/help.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 files[] = help.test
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/image/image.admin.inc
+++ b/docroot/modules/image/image.admin.inc
@@ -736,7 +736,8 @@ function theme_image_style_effects($variables) {
     if (!isset($form[$key]['#access']) || $form[$key]['#access']) {
       $rows[] = array(
         'data' => $row,
-        'class' => !empty($form[$key]['weight']['#access']) || $key == 'new' ? array('draggable') : array(),
+        // Use a strict (===) comparison since $key can be 0.
+        'class' => !empty($form[$key]['weight']['#access']) || $key === 'new' ? array('draggable') : array(),
       );
     }
   }

--- a/docroot/modules/image/image.info
+++ b/docroot/modules/image/image.info
@@ -7,7 +7,7 @@ dependencies[] = file
 files[] = image.test
 configure = admin/config/media/image-styles
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/image/tests/image_module_test.info
+++ b/docroot/modules/image/tests/image_module_test.info
@@ -6,7 +6,7 @@ core = 7.x
 files[] = image_module_test.module
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/locale/locale.info
+++ b/docroot/modules/locale/locale.info
@@ -6,7 +6,7 @@ core = 7.x
 files[] = locale.test
 configure = admin/config/regional/language
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/locale/locale.test
+++ b/docroot/modules/locale/locale.test
@@ -3188,11 +3188,7 @@ class LocaleLanguageNegotiationInfoFunctionalTest extends DrupalWebTestCase {
     foreach (language_types_info() as $type => $info) {
       if (isset($info['fixed'])) {
         $negotiation = variable_get("language_negotiation_$type", array());
-        $equal = count($info['fixed']) == count($negotiation);
-        while ($equal && list($id) = each($negotiation)) {
-          list(, $info_id) = each($info['fixed']);
-          $equal = $info_id == $id;
-        }
+        $equal = array_keys($negotiation) === array_values($info['fixed']);
         $this->assertTrue($equal, format_string('language negotiation for %type is properly set up', array('%type' => $type)));
       }
     }

--- a/docroot/modules/locale/tests/locale_test.info
+++ b/docroot/modules/locale/tests/locale_test.info
@@ -5,7 +5,7 @@ package = Testing
 version = VERSION
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/menu/menu.info
+++ b/docroot/modules/menu/menu.info
@@ -6,7 +6,7 @@ core = 7.x
 files[] = menu.test
 configure = admin/structure/menu
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/node/node.info
+++ b/docroot/modules/node/node.info
@@ -9,7 +9,7 @@ required = TRUE
 configure = admin/structure/types
 stylesheets[all][] = node.css
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/node/tests/node_access_test.info
+++ b/docroot/modules/node/tests/node_access_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/node/tests/node_test.info
+++ b/docroot/modules/node/tests/node_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/node/tests/node_test_exception.info
+++ b/docroot/modules/node/tests/node_test_exception.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/openid/openid.info
+++ b/docroot/modules/openid/openid.info
@@ -5,7 +5,7 @@ package = Core
 core = 7.x
 files[] = openid.test
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/openid/tests/openid_test.info
+++ b/docroot/modules/openid/tests/openid_test.info
@@ -6,7 +6,7 @@ core = 7.x
 dependencies[] = openid
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/overlay/overlay.info
+++ b/docroot/modules/overlay/overlay.info
@@ -4,7 +4,7 @@ package = Core
 version = VERSION
 core = 7.x
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/path/path.info
+++ b/docroot/modules/path/path.info
@@ -6,7 +6,7 @@ core = 7.x
 files[] = path.test
 configure = admin/config/search/path
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/php/php.info
+++ b/docroot/modules/php/php.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 files[] = php.test
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/poll/poll.info
+++ b/docroot/modules/poll/poll.info
@@ -6,7 +6,7 @@ core = 7.x
 files[] = poll.test
 stylesheets[all][] = poll.css
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/profile/profile.info
+++ b/docroot/modules/profile/profile.info
@@ -11,7 +11,7 @@ configure = admin/config/people/profile
 ; See user_system_info_alter().
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/rdf/rdf.info
+++ b/docroot/modules/rdf/rdf.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 files[] = rdf.test
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/rdf/tests/rdf_test.info
+++ b/docroot/modules/rdf/tests/rdf_test.info
@@ -6,7 +6,7 @@ core = 7.x
 hidden = TRUE
 dependencies[] = blog
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/search/search.info
+++ b/docroot/modules/search/search.info
@@ -8,7 +8,7 @@ files[] = search.test
 configure = admin/config/search/settings
 stylesheets[all][] = search.css
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/search/tests/search_embedded_form.info
+++ b/docroot/modules/search/tests/search_embedded_form.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/search/tests/search_extra_type.info
+++ b/docroot/modules/search/tests/search_extra_type.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/search/tests/search_node_tags.info
+++ b/docroot/modules/search/tests/search_node_tags.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/shortcut/shortcut.info
+++ b/docroot/modules/shortcut/shortcut.info
@@ -6,7 +6,7 @@ core = 7.x
 files[] = shortcut.test
 configure = admin/config/user-interface/shortcut
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/simpletest/simpletest.info
+++ b/docroot/modules/simpletest/simpletest.info
@@ -57,7 +57,7 @@ files[] = tests/upgrade/update.trigger.test
 files[] = tests/upgrade/update.field.test
 files[] = tests/upgrade/update.user.test
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/simpletest/tests/actions_loop_test.info
+++ b/docroot/modules/simpletest/tests/actions_loop_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/simpletest/tests/ajax_forms_test.info
+++ b/docroot/modules/simpletest/tests/ajax_forms_test.info
@@ -5,7 +5,7 @@ package = Testing
 version = VERSION
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/simpletest/tests/ajax_test.info
+++ b/docroot/modules/simpletest/tests/ajax_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/simpletest/tests/batch_test.info
+++ b/docroot/modules/simpletest/tests/batch_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/simpletest/tests/boot_test_1.info
+++ b/docroot/modules/simpletest/tests/boot_test_1.info
@@ -5,7 +5,7 @@ package = Testing
 version = VERSION
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/simpletest/tests/boot_test_2.info
+++ b/docroot/modules/simpletest/tests/boot_test_2.info
@@ -5,7 +5,7 @@ package = Testing
 version = VERSION
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/simpletest/tests/common_test.info
+++ b/docroot/modules/simpletest/tests/common_test.info
@@ -7,7 +7,7 @@ stylesheets[all][] = common_test.css
 stylesheets[print][] = common_test.print.css
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/simpletest/tests/common_test_cron_helper.info
+++ b/docroot/modules/simpletest/tests/common_test_cron_helper.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/simpletest/tests/database_test.info
+++ b/docroot/modules/simpletest/tests/database_test.info
@@ -5,7 +5,7 @@ package = Testing
 version = VERSION
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/simpletest/tests/drupal_autoload_test/drupal_autoload_test.info
+++ b/docroot/modules/simpletest/tests/drupal_autoload_test/drupal_autoload_test.info
@@ -7,7 +7,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/simpletest/tests/drupal_system_listing_compatible_test/drupal_system_listing_compatible_test.info
+++ b/docroot/modules/simpletest/tests/drupal_system_listing_compatible_test/drupal_system_listing_compatible_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/simpletest/tests/drupal_system_listing_incompatible_test/drupal_system_listing_incompatible_test.info
+++ b/docroot/modules/simpletest/tests/drupal_system_listing_incompatible_test/drupal_system_listing_incompatible_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/simpletest/tests/entity_cache_test.info
+++ b/docroot/modules/simpletest/tests/entity_cache_test.info
@@ -6,7 +6,7 @@ core = 7.x
 dependencies[] = entity_cache_test_dependency
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/simpletest/tests/entity_cache_test_dependency.info
+++ b/docroot/modules/simpletest/tests/entity_cache_test_dependency.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/simpletest/tests/entity_crud_hook_test.info
+++ b/docroot/modules/simpletest/tests/entity_crud_hook_test.info
@@ -5,7 +5,7 @@ package = Testing
 version = VERSION
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/simpletest/tests/entity_query_access_test.info
+++ b/docroot/modules/simpletest/tests/entity_query_access_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/simpletest/tests/error_test.info
+++ b/docroot/modules/simpletest/tests/error_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/simpletest/tests/file_test.info
+++ b/docroot/modules/simpletest/tests/file_test.info
@@ -6,7 +6,7 @@ core = 7.x
 files[] = file_test.module
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/simpletest/tests/filter_test.info
+++ b/docroot/modules/simpletest/tests/filter_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/simpletest/tests/form.test
+++ b/docroot/modules/simpletest/tests/form.test
@@ -1421,6 +1421,59 @@ class FormsFormStoragePageCacheTestCase extends DrupalWebTestCase {
 }
 
 /**
+ * Test cache_form.
+ */
+class FormsFormCacheTestCase extends DrupalWebTestCase {
+  public static function getInfo() {
+    return array(
+      'name' => 'Form caching',
+      'description' => 'Tests storage and retrieval of forms from cache.',
+      'group' => 'Form API',
+    );
+  }
+
+  function setUp() {
+    parent::setUp('form_test');
+  }
+
+  /**
+   * Tests storing and retrieving the form from cache.
+   */
+  function testCacheForm() {
+    $form = drupal_get_form('form_test_cache_form');
+    $form_state = array('foo' => 'bar', 'build_info' => array('baz'));
+    form_set_cache($form['#build_id'], $form, $form_state);
+
+    $cached_form_state = array();
+    $cached_form = form_get_cache($form['#build_id'], $cached_form_state);
+
+    $this->assertEqual($cached_form['#build_id'], $form['#build_id'], 'Form retrieved from cache_form successfully.');
+    $this->assertEqual($cached_form_state['foo'], 'bar', 'Data retrieved from cache_form successfully.');
+  }
+
+  /**
+   * Tests changing form_cache_expiration.
+   */
+  function testCacheFormCustomExpiration() {
+    variable_set('form_cache_expiration', -1 * (24 * 60 * 60));
+
+    $form = drupal_get_form('form_test_cache_form');
+    $form_state = array('foo' => 'bar', 'build_info' => array('baz'));
+    form_set_cache($form['#build_id'], $form, $form_state);
+
+    // Clear expired entries from cache_form, which should include the entry we
+    // just stored. Without this, the form will still be retrieved from cache.
+    cache_clear_all(NULL, 'cache_form');
+
+    $cached_form_state = array();
+    $cached_form = form_get_cache($form['#build_id'], $cached_form_state);
+
+    $this->assertNull($cached_form, 'Expired form was not returned from cache.');
+    $this->assertTrue(empty($cached_form_state), 'No data retrieved from cache for expired form.');
+  }
+}
+
+/**
  * Test wrapper form callbacks.
  */
 class FormsFormWrapperTestCase extends DrupalWebTestCase {

--- a/docroot/modules/simpletest/tests/form_test.info
+++ b/docroot/modules/simpletest/tests/form_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/simpletest/tests/form_test.module
+++ b/docroot/modules/simpletest/tests/form_test.module
@@ -919,6 +919,24 @@ function form_test_storage_page_cache_rebuild($form, &$form_state) {
 }
 
 /**
+ * A simple form for testing form caching.
+ */
+function form_test_cache_form($form, &$form_state) {
+  $form['title'] = array(
+    '#type' => 'textfield',
+    '#title' => 'Title',
+    '#required' => TRUE,
+  );
+
+  $form['submit'] = array(
+    '#type' => 'submit',
+    '#value' => 'Save',
+  );
+
+  return $form;
+}
+
+/**
  * A form for testing form labels and required marks.
  */
 function form_label_test_form() {

--- a/docroot/modules/simpletest/tests/image.test
+++ b/docroot/modules/simpletest/tests/image.test
@@ -335,7 +335,9 @@ class ImageToolkitGdTestCase extends DrupalWebTestCase {
     );
 
     // Systems using non-bundled GD2 don't have imagerotate. Test if available.
-    if (function_exists('imagerotate')) {
+    // @todo Remove the version check once https://www.drupal.org/node/2918570
+    //   is resolved.
+    if (function_exists('imagerotate') && (version_compare(PHP_VERSION, '7.0.26', '<') || (version_compare(PHP_VERSION, '7.1', '>=') && version_compare(PHP_VERSION, '7.1.12', '<')))) {
       $operations += array(
         'rotate_90' => array(
           'function' => 'rotate',
@@ -357,8 +359,8 @@ class ImageToolkitGdTestCase extends DrupalWebTestCase {
       // See https://bugs.php.net/bug.php?id=65148.
       // For the 40x20 test images, the dimensions resulting from rotation will
       // be 1 pixel smaller in both width and height in PHP 5.5 and above.
-      // @todo: If and when the PHP bug gets solved, add an upper limit
-      //   version check.
+      // @todo: The PHP bug was fixed in PHP 7.0.26 and 7.1.12. Change the code
+      //   below to reflect that in https://www.drupal.org/node/2918570.
       if (version_compare(PHP_VERSION, '5.5', '>=')) {
         $operations += array(
           'rotate_5' => array(

--- a/docroot/modules/simpletest/tests/image_test.info
+++ b/docroot/modules/simpletest/tests/image_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/simpletest/tests/menu_test.info
+++ b/docroot/modules/simpletest/tests/menu_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/simpletest/tests/module_test.info
+++ b/docroot/modules/simpletest/tests/module_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/simpletest/tests/path_test.info
+++ b/docroot/modules/simpletest/tests/path_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/simpletest/tests/psr_0_test/psr_0_test.info
+++ b/docroot/modules/simpletest/tests/psr_0_test/psr_0_test.info
@@ -5,7 +5,7 @@ core = 7.x
 hidden = TRUE
 package = Testing
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/simpletest/tests/psr_4_test/psr_4_test.info
+++ b/docroot/modules/simpletest/tests/psr_4_test/psr_4_test.info
@@ -5,7 +5,7 @@ core = 7.x
 hidden = TRUE
 package = Testing
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/simpletest/tests/requirements1_test.info
+++ b/docroot/modules/simpletest/tests/requirements1_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/simpletest/tests/requirements2_test.info
+++ b/docroot/modules/simpletest/tests/requirements2_test.info
@@ -7,7 +7,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/simpletest/tests/session_test.info
+++ b/docroot/modules/simpletest/tests/session_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/simpletest/tests/system_dependencies_test.info
+++ b/docroot/modules/simpletest/tests/system_dependencies_test.info
@@ -6,7 +6,7 @@ core = 7.x
 hidden = TRUE
 dependencies[] = _missing_dependency
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/simpletest/tests/system_incompatible_core_version_dependencies_test.info
+++ b/docroot/modules/simpletest/tests/system_incompatible_core_version_dependencies_test.info
@@ -6,7 +6,7 @@ core = 7.x
 hidden = TRUE
 dependencies[] = system_incompatible_core_version_test
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/simpletest/tests/system_incompatible_core_version_test.info
+++ b/docroot/modules/simpletest/tests/system_incompatible_core_version_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 5.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/simpletest/tests/system_incompatible_module_version_dependencies_test.info
+++ b/docroot/modules/simpletest/tests/system_incompatible_module_version_dependencies_test.info
@@ -7,7 +7,7 @@ hidden = TRUE
 ; system_incompatible_module_version_test declares version 1.0
 dependencies[] = system_incompatible_module_version_test (>2.0)
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/simpletest/tests/system_incompatible_module_version_test.info
+++ b/docroot/modules/simpletest/tests/system_incompatible_module_version_test.info
@@ -5,7 +5,7 @@ version = 1.0
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/simpletest/tests/system_project_namespace_test.info
+++ b/docroot/modules/simpletest/tests/system_project_namespace_test.info
@@ -6,7 +6,7 @@ core = 7.x
 hidden = TRUE
 dependencies[] = drupal:filter
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/simpletest/tests/system_test.info
+++ b/docroot/modules/simpletest/tests/system_test.info
@@ -6,7 +6,7 @@ core = 7.x
 files[] = system_test.module
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/simpletest/tests/taxonomy_test.info
+++ b/docroot/modules/simpletest/tests/taxonomy_test.info
@@ -6,7 +6,7 @@ core = 7.x
 hidden = TRUE
 dependencies[] = taxonomy
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/simpletest/tests/theme_test.info
+++ b/docroot/modules/simpletest/tests/theme_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/simpletest/tests/themes/test_basetheme/test_basetheme.info
+++ b/docroot/modules/simpletest/tests/themes/test_basetheme/test_basetheme.info
@@ -6,7 +6,7 @@ hidden = TRUE
 settings[basetheme_only] = base theme value
 settings[subtheme_override] = base theme value
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/simpletest/tests/themes/test_subtheme/test_subtheme.info
+++ b/docroot/modules/simpletest/tests/themes/test_subtheme/test_subtheme.info
@@ -6,7 +6,7 @@ hidden = TRUE
 
 settings[subtheme_override] = subtheme value
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/simpletest/tests/themes/test_theme/test_theme.info
+++ b/docroot/modules/simpletest/tests/themes/test_theme/test_theme.info
@@ -17,7 +17,7 @@ stylesheets[all][] = system.base.css
 
 settings[theme_test_setting] = default value
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/simpletest/tests/themes/test_theme/theme-settings.php
+++ b/docroot/modules/simpletest/tests/themes/test_theme/theme-settings.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * @file
+ * Theme setting callbacks for the test_theme theme.
+ */
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function test_theme_form_system_theme_settings_alter(&$form, &$form_state) {
+  $form['test_theme_checkbox'] = array(
+    '#type' => 'checkbox',
+    '#title' => 'Test theme checkbox',
+    '#default_value' => theme_get_setting('test_theme_checkbox'),
+  );
+
+  // Force the form to be cached so we can test that this file is properly
+  // loaded and the custom submit handler is properly called even on a cached
+  // form build.
+  $form_state['cache'] = TRUE;
+  $form['#submit'][] = 'test_theme_form_system_theme_settings_submit';
+}
+
+/**
+ * Form submission handler for the test theme settings form.
+ *
+ * @see test_theme_form_system_theme_settings_alter()
+ */
+function test_theme_form_system_theme_settings_submit($form, &$form_state) {
+  drupal_set_message('The test theme setting was saved.');
+}

--- a/docroot/modules/simpletest/tests/themes/test_theme_nyan_cat/test_theme_nyan_cat.info
+++ b/docroot/modules/simpletest/tests/themes/test_theme_nyan_cat/test_theme_nyan_cat.info
@@ -4,7 +4,7 @@ core = 7.x
 hidden = TRUE
 engine = nyan_cat
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/simpletest/tests/update_script_test.info
+++ b/docroot/modules/simpletest/tests/update_script_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/simpletest/tests/update_test_1.info
+++ b/docroot/modules/simpletest/tests/update_test_1.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/simpletest/tests/update_test_2.info
+++ b/docroot/modules/simpletest/tests/update_test_2.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/simpletest/tests/update_test_3.info
+++ b/docroot/modules/simpletest/tests/update_test_3.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/simpletest/tests/url_alter_test.info
+++ b/docroot/modules/simpletest/tests/url_alter_test.info
@@ -5,7 +5,7 @@ package = Testing
 version = VERSION
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/simpletest/tests/xmlrpc_test.info
+++ b/docroot/modules/simpletest/tests/xmlrpc_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/statistics/statistics.info
+++ b/docroot/modules/statistics/statistics.info
@@ -6,7 +6,7 @@ core = 7.x
 files[] = statistics.test
 configure = admin/config/system/statistics
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/syslog/syslog.info
+++ b/docroot/modules/syslog/syslog.info
@@ -6,7 +6,7 @@ core = 7.x
 files[] = syslog.test
 configure = admin/config/development/logging
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/system/system.admin.inc
+++ b/docroot/modules/system/system.admin.inc
@@ -572,9 +572,10 @@ function system_theme_settings($form, &$form_state, $key = '') {
     // Process the theme and all its base themes.
     foreach ($theme_keys as $theme) {
       // Include the theme-settings.php file.
-      $filename = DRUPAL_ROOT . '/' . str_replace("/$theme.info", '', $themes[$theme]->filename) . '/theme-settings.php';
-      if (file_exists($filename)) {
-        require_once $filename;
+      $theme_settings_path = drupal_get_path('theme', $theme) . '/theme-settings.php';
+      if (file_exists(DRUPAL_ROOT . '/' . $theme_settings_path)) {
+        require_once DRUPAL_ROOT . '/' . $theme_settings_path;
+        $form_state['build_info']['files'][] = $theme_settings_path;
       }
 
       // Call theme-specific settings.
@@ -1812,7 +1813,7 @@ function system_file_system_settings() {
     '#title' => t('Private file system path'),
     '#default_value' => variable_get('file_private_path', ''),
     '#maxlength' => 255,
-    '#description' => t('An existing local file system path for storing private files. It should be writable by Drupal and not accessible over the web. See the online handbook for <a href="@handbook">more information about securing private files</a>.', array('@handbook' => 'http://drupal.org/documentation/modules/file')),
+    '#description' => t('An existing local file system path for storing private files. It should be writable by Drupal and not accessible over the web. See the online handbook for <a href="@handbook">more information about securing private files</a>.', array('@handbook' => 'https://www.drupal.org/docs/7/core/modules/file/overview')),
     '#after_build' => array('system_check_directory'),
   );
 
@@ -2565,9 +2566,21 @@ function theme_system_admin_index($variables) {
 /**
  * Returns HTML for the status report.
  *
+ * This theme function is dependent on install.inc being loaded, because
+ * that's where the constants are defined.
+ *
  * @param $variables
  *   An associative array containing:
- *   - requirements: An array of requirements.
+ *   - requirements: An array of requirements/status items. Each requirement
+ *     is an associative array containing the following elements:
+ *     - title: The name of the requirement.
+ *     - value: (optional) The current value (version, time, level, etc).
+ *     - description: (optional) The description of the requirement.
+ *     - severity: (optional) The requirement's result/severity level, one of:
+ *       - REQUIREMENT_INFO: Status information.
+ *       - REQUIREMENT_OK: The requirement is satisfied.
+ *       - REQUIREMENT_WARNING: The requirement failed with a warning.
+ *       - REQUIREMENT_ERROR: The requirement failed with an error.
  *
  * @ingroup themeable
  */

--- a/docroot/modules/system/system.api.php
+++ b/docroot/modules/system/system.api.php
@@ -1888,8 +1888,8 @@ function hook_boot() {
  *
  * This hook is not run on cached pages.
  *
- * To add CSS or JS that should be present on all pages, modules should not
- * implement this hook, but declare these files in their .info file.
+ * To add CSS or JS files that should be present on all pages, modules should
+ * not implement this hook, but declare these files in their .info file.
  *
  * @see hook_boot()
  */

--- a/docroot/modules/system/system.info
+++ b/docroot/modules/system/system.info
@@ -12,7 +12,7 @@ files[] = system.test
 required = TRUE
 configure = admin/config/system
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/system/system.tar.inc
+++ b/docroot/modules/system/system.tar.inc
@@ -41,8 +41,8 @@
 
  /**
  * Note on Drupal 8 porting.
- * This file origin is Tar.php, release 1.4.0 (stable) with some code
- * from PEAR.php, release 1.9.5 (stable) both at http://pear.php.net.
+ * This file origin is Tar.php, release 1.4.3 (stable) with some code
+ * from PEAR.php, release 1.10.5 (stable) both at http://pear.php.net.
  * To simplify future porting from pear of this file, you should not
  * do cosmetic or other non significant changes to this file.
  * The following changes have been done:
@@ -259,6 +259,19 @@ class Archive_Tar
                 return false;
             }
         }
+
+
+        if (version_compare(PHP_VERSION, "5.5.0-dev") < 0) {
+            $this->_fmt = "a100filename/a8mode/a8uid/a8gid/a12size/a12mtime/" .
+                   "a8checksum/a1typeflag/a100link/a6magic/a2version/" .
+                   "a32uname/a32gname/a8devmajor/a8devminor/a131prefix";
+        } else {
+            $this->_fmt = "Z100filename/Z8mode/Z8uid/Z8gid/Z12size/Z12mtime/" .
+                   "Z8checksum/Z1typeflag/Z100link/Z6magic/Z2version/" .
+                   "Z32uname/Z32gname/Z8devmajor/Z8devminor/Z131prefix";
+        }
+
+
     }
 
     public function __destruct()
@@ -278,7 +291,7 @@ class Archive_Tar
     * @param string $ext The extension name
     * @return bool Success or not on the dl() call
     */
-    function loadExtension($ext)
+    public static function loadExtension($ext)
     {
         if (extension_loaded($ext)) {
             return true;
@@ -287,8 +300,7 @@ class Archive_Tar
         // if either returns true dl() will produce a FATAL error, stop that
         if (
             function_exists('dl') === false ||
-            ini_get('enable_dl') != 1 ||
-            ini_get('safe_mode') == 1
+            ini_get('enable_dl') != 1
         ) {
             return false;
         }
@@ -714,7 +726,7 @@ class Archive_Tar
         }
 
         // ----- Get the arguments
-        $v_att_list = & func_get_args();
+        $v_att_list = func_get_args();
 
         // ----- Read the attributes
         $i = 0;
@@ -1720,28 +1732,13 @@ class Archive_Tar
         // ----- Calculate the checksum
         $v_checksum = 0;
         // ..... First part of the header
-        for ($i = 0; $i < 148; $i++) {
-            $v_checksum += ord(substr($v_binary_data, $i, 1));
-        }
-        // ..... Ignore the checksum value and replace it by ' ' (space)
-        for ($i = 148; $i < 156; $i++) {
-            $v_checksum += ord(' ');
-        }
-        // ..... Last part of the header
-        for ($i = 156; $i < 512; $i++) {
-            $v_checksum += ord(substr($v_binary_data, $i, 1));
-        }
+        $v_binary_split = str_split($v_binary_data);
+        $v_checksum += array_sum(array_map('ord', array_slice($v_binary_split, 0, 148)));
+        $v_checksum += array_sum(array_map('ord', array(' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',)));
+        $v_checksum += array_sum(array_map('ord', array_slice($v_binary_split, 156, 512)));
 
-        if (version_compare(PHP_VERSION, "5.5.0-dev") < 0) {
-            $fmt = "a100filename/a8mode/a8uid/a8gid/a12size/a12mtime/" .
-                "a8checksum/a1typeflag/a100link/a6magic/a2version/" .
-                "a32uname/a32gname/a8devmajor/a8devminor/a131prefix";
-        } else {
-            $fmt = "Z100filename/Z8mode/Z8uid/Z8gid/Z12size/Z12mtime/" .
-                "Z8checksum/Z1typeflag/Z100link/Z6magic/Z2version/" .
-                "Z32uname/Z32gname/Z8devmajor/Z8devminor/Z131prefix";
-        }
-        $v_data = unpack($fmt, $v_binary_data);
+
+        $v_data = unpack($this->_fmt, $v_binary_data);
 
         if (strlen($v_data["prefix"]) > 0) {
             $v_data["filename"] = "$v_data[prefix]/$v_data[filename]";
@@ -1777,7 +1774,7 @@ class Archive_Tar
         $v_header['mode'] = OctDec(trim($v_data['mode']));
         $v_header['uid'] = OctDec(trim($v_data['uid']));
         $v_header['gid'] = OctDec(trim($v_data['gid']));
-        $v_header['size'] = OctDec(trim($v_data['size']));
+        $v_header['size'] = $this->_tarRecToSize($v_data['size']);
         $v_header['mtime'] = OctDec(trim($v_data['mtime']));
         if (($v_header['typeflag'] = $v_data['typeflag']) == "5") {
             $v_header['size'] = 0;
@@ -1794,6 +1791,40 @@ class Archive_Tar
         */
 
         return true;
+    }
+
+    /**
+     * Convert Tar record size to actual size
+     *
+     * @param string $tar_size
+     * @return size of tar record in bytes
+     */
+    private function _tarRecToSize($tar_size)
+    {
+        /*
+         * First byte of size has a special meaning if bit 7 is set.
+         *
+         * Bit 7 indicates base-256 encoding if set.
+         * Bit 6 is the sign bit.
+         * Bits 5:0 are most significant value bits.
+         */
+        $ch = ord($tar_size[0]);
+        if ($ch & 0x80) {
+            // Full 12-bytes record is required.
+            $rec_str = $tar_size . "\x00";
+
+            $size = ($ch & 0x40) ? -1 : 0;
+            $size = ($size << 6) | ($ch & 0x3f);
+
+            for ($num_ch = 1; $num_ch < 12; ++$num_ch) {
+                $size = ($size * 256) + ord($rec_str[$num_ch]);
+            }
+
+            return $size;
+
+        } else {
+            return OctDec(trim($tar_size));
+        }
     }
 
     /**

--- a/docroot/modules/system/system.test
+++ b/docroot/modules/system/system.test
@@ -1944,6 +1944,30 @@ class SystemThemeFunctionalTest extends DrupalWebTestCase {
     $this->assertEqual($elements[0]['src'], file_create_url($uploaded_filename));
   }
 
+
+  /**
+   * Test the individual per-theme settings form.
+   */
+  function testPerThemeSettings() {
+    // Enable the test theme and the module that controls it. Clear caches in
+    // between so that the module's hook_system_theme_info() implementation is
+    // correctly registered.
+    module_enable(array('theme_test'));
+    drupal_flush_all_caches();
+    theme_enable(array('test_theme'));
+
+    // Test that the theme-specific settings form can be saved and that the
+    // theme-specific checkbox is checked and unchecked as appropriate.
+    $this->drupalGet('admin/appearance/settings/test_theme');
+    $this->assertNoFieldChecked('edit-test-theme-checkbox', 'The test_theme_checkbox setting is unchecked.');
+    $this->drupalPost(NULL, array('test_theme_checkbox' => TRUE), t('Save configuration'));
+    $this->assertText('The test theme setting was saved.');
+    $this->assertFieldChecked('edit-test-theme-checkbox', 'The test_theme_checkbox setting is checked.');
+    $this->drupalPost(NULL, array('test_theme_checkbox' => FALSE), t('Save configuration'));
+    $this->assertText('The test theme setting was saved.');
+    $this->assertNoFieldChecked('edit-test-theme-checkbox', 'The test_theme_checkbox setting is unchecked.');
+  }
+
   /**
    * Test the administration theme functionality.
    */

--- a/docroot/modules/system/tests/cron_queue_test.info
+++ b/docroot/modules/system/tests/cron_queue_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/system/tests/system_cron_test.info
+++ b/docroot/modules/system/tests/system_cron_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/taxonomy/taxonomy.info
+++ b/docroot/modules/taxonomy/taxonomy.info
@@ -8,7 +8,7 @@ files[] = taxonomy.module
 files[] = taxonomy.test
 configure = admin/structure/taxonomy
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/taxonomy/taxonomy.module
+++ b/docroot/modules/taxonomy/taxonomy.module
@@ -283,6 +283,8 @@ function taxonomy_menu() {
     'title' => 'Taxonomy term',
     'title callback' => 'taxonomy_term_title',
     'title arguments' => array(2),
+    // The page callback also invokes drupal_set_title() in case
+    // the menu router's title is overridden by a menu link.
     'page callback' => 'taxonomy_term_page',
     'page arguments' => array(2),
     'access arguments' => array('access content'),
@@ -1714,13 +1716,15 @@ function taxonomy_field_formatter_prepare_view($entity_type, $entities, $field, 
 }
 
 /**
- * Title callback for term pages.
+ * Title callback: Returns the title of the taxonomy term.
  *
  * @param $term
  *   A term object.
  *
  * @return
- *   The term name to be used as the page title.
+ *   An unsanitized string that is the title of the taxonomy term.
+ *
+ * @see taxonomy_menu()
  */
 function taxonomy_term_title($term) {
   return $term->name;

--- a/docroot/modules/toolbar/toolbar.info
+++ b/docroot/modules/toolbar/toolbar.info
@@ -4,7 +4,7 @@ core = 7.x
 package = Core
 version = VERSION
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/tracker/tracker.info
+++ b/docroot/modules/tracker/tracker.info
@@ -6,7 +6,7 @@ version = VERSION
 core = 7.x
 files[] = tracker.test
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/translation/tests/translation_test.info
+++ b/docroot/modules/translation/tests/translation_test.info
@@ -5,7 +5,7 @@ package = Testing
 version = VERSION
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/translation/translation.info
+++ b/docroot/modules/translation/translation.info
@@ -6,7 +6,7 @@ version = VERSION
 core = 7.x
 files[] = translation.test
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/trigger/tests/trigger_test.info
+++ b/docroot/modules/trigger/tests/trigger_test.info
@@ -4,7 +4,7 @@ package = Testing
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/trigger/trigger.info
+++ b/docroot/modules/trigger/trigger.info
@@ -6,7 +6,7 @@ core = 7.x
 files[] = trigger.test
 configure = admin/structure/trigger
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/update/tests/aaa_update_test.info
+++ b/docroot/modules/update/tests/aaa_update_test.info
@@ -4,7 +4,7 @@ package = Testing
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/update/tests/bbb_update_test.info
+++ b/docroot/modules/update/tests/bbb_update_test.info
@@ -4,7 +4,7 @@ package = Testing
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/update/tests/ccc_update_test.info
+++ b/docroot/modules/update/tests/ccc_update_test.info
@@ -4,7 +4,7 @@ package = Testing
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/update/tests/themes/update_test_admintheme/update_test_admintheme.info
+++ b/docroot/modules/update/tests/themes/update_test_admintheme/update_test_admintheme.info
@@ -3,7 +3,7 @@ description = Test theme which is used as admin theme.
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/update/tests/themes/update_test_basetheme/update_test_basetheme.info
+++ b/docroot/modules/update/tests/themes/update_test_basetheme/update_test_basetheme.info
@@ -3,7 +3,7 @@ description = Test theme which acts as a base theme for other test subthemes.
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/update/tests/themes/update_test_subtheme/update_test_subtheme.info
+++ b/docroot/modules/update/tests/themes/update_test_subtheme/update_test_subtheme.info
@@ -4,7 +4,7 @@ core = 7.x
 base theme = update_test_basetheme
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/update/tests/update_test.info
+++ b/docroot/modules/update/tests/update_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/update/update.info
+++ b/docroot/modules/update/update.info
@@ -6,7 +6,7 @@ core = 7.x
 files[] = update.test
 configure = admin/reports/updates/settings
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/user/tests/user_form_test.info
+++ b/docroot/modules/user/tests/user_form_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/user/user.info
+++ b/docroot/modules/user/user.info
@@ -9,7 +9,7 @@ required = TRUE
 configure = admin/config/people
 stylesheets[all][] = user.css
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/modules/user/user.module
+++ b/docroot/modules/user/user.module
@@ -637,7 +637,7 @@ function user_validate_name($name) {
   if (strpos($name, '  ') !== FALSE) {
     return t('The username cannot contain multiple spaces in a row.');
   }
-  if (preg_match('/[^\x{80}-\x{F7} a-z0-9@_.\'-]/i', $name)) {
+  if (preg_match('/[^\x{80}-\x{F7} a-z0-9@+_.\'-]/i', $name)) {
     return t('The username contains an illegal character.');
   }
   if (preg_match('/[\x{80}-\x{A0}' .         // Non-printable ISO-8859-1 + NBSP
@@ -689,7 +689,7 @@ function user_validate_picture(&$form, &$form_state) {
   $validators = array(
     'file_validate_is_image' => array(),
     'file_validate_image_resolution' => array(variable_get('user_picture_dimensions', '85x85')),
-    'file_validate_size' => array(variable_get('user_picture_file_size', '30') * 1024),
+    'file_validate_size' => array((int) variable_get('user_picture_file_size', '30') * 1024),
   );
 
   // Save the file as a temporary file.

--- a/docroot/modules/user/user.test
+++ b/docroot/modules/user/user.test
@@ -276,6 +276,7 @@ class UserValidationTestCase extends DrupalWebTestCase {
       'foo@example.com'        => array('Valid username', 'assertNull'),
       'foo@-example.com'       => array('Valid username', 'assertNull'), // invalid domains are allowed in usernames
       'þòøÇßªř€'               => array('Valid username', 'assertNull'),
+      'foo+bar'                => array('Valid username', 'assertNull'), // '+' symbol is allowed
       'ᚠᛇᚻ᛫ᛒᛦᚦ'                => array('Valid UTF8 username', 'assertNull'), // runes
       ' foo'                   => array('Invalid username that starts with a space', 'assertNotNull'),
       'foo '                   => array('Invalid username that ends with a space', 'assertNotNull'),
@@ -2386,7 +2387,13 @@ class UserUserSearchTestCase extends DrupalWebTestCase {
   }
 
   function testUserSearch() {
+    // Verify that a user without 'administer users' permission cannot search
+    // for users by email address. Additionally, ensure that the username has a
+    // plus sign to ensure searching works with that.
     $user1 = $this->drupalCreateUser(array('access user profiles', 'search content', 'use advanced search'));
+    $edit['name'] = 'foo+bar';
+    $edit['mail'] = $edit['name'] . '@example.com';
+    user_save($user1, $edit);
     $this->drupalLogin($user1);
     $keys = $user1->mail;
     $edit = array('keys' => $keys);

--- a/docroot/profiles/minimal/minimal.info
+++ b/docroot/profiles/minimal/minimal.info
@@ -5,7 +5,7 @@ core = 7.x
 dependencies[] = block
 dependencies[] = dblog
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/profiles/standard/standard.info
+++ b/docroot/profiles/standard/standard.info
@@ -24,7 +24,7 @@ dependencies[] = field_ui
 dependencies[] = file
 dependencies[] = rdf
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/profiles/testing/modules/drupal_system_listing_compatible_test/drupal_system_listing_compatible_test.info
+++ b/docroot/profiles/testing/modules/drupal_system_listing_compatible_test/drupal_system_listing_compatible_test.info
@@ -6,7 +6,7 @@ core = 7.x
 hidden = TRUE
 files[] = drupal_system_listing_compatible_test.test
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/profiles/testing/modules/drupal_system_listing_incompatible_test/drupal_system_listing_incompatible_test.info
+++ b/docroot/profiles/testing/modules/drupal_system_listing_incompatible_test/drupal_system_listing_incompatible_test.info
@@ -8,7 +8,7 @@ version = VERSION
 core = 6.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/profiles/testing/testing.info
+++ b/docroot/profiles/testing/testing.info
@@ -4,7 +4,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/themes/bartik/bartik.info
+++ b/docroot/themes/bartik/bartik.info
@@ -34,7 +34,7 @@ regions[footer] = Footer
 settings[shortcut_module_link] = 0
 
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/themes/garland/garland.info
+++ b/docroot/themes/garland/garland.info
@@ -7,7 +7,7 @@ stylesheets[all][] = style.css
 stylesheets[print][] = print.css
 settings[garland_width] = fluid
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/themes/seven/seven.info
+++ b/docroot/themes/seven/seven.info
@@ -13,7 +13,7 @@ regions[page_bottom] = Page bottom
 regions[sidebar_first] = First sidebar
 regions_hidden[] = sidebar_first
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"

--- a/docroot/themes/stark/stark.info
+++ b/docroot/themes/stark/stark.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 stylesheets[all][] = layout.css
 
-; Information added by Drupal.org packaging script on 2018-10-17
-version = "7.60"
+; Information added by Drupal.org packaging script on 2018-11-08
+version = "7.61"
 project = "drupal"
-datestamp = "1539816636"
+datestamp = "1541684322"


### PR DESCRIPTION
I was unable to get the environment running due to this error:
```
ERROR: for d7a_browser_1  Cannot start service browser: driver failed programming external connectivity on endpoint d7a_browser_1 (9a442f810e25db3eb4
ERROR: for browser  Cannot start service browser: driver failed programming external connectivity on endpoint d7a_browser_1 (9a442f810e25db3eb4ac1e8ffb2331f7d52d55d6a7d32830d2f6fc18f03b6463): Error starting userland proxy: Bind for 0.0.0.0:5900 failed: port is already allocated
ERROR: Encountered errors while bringing up the project.
```

My workaround was to remove the browser config from the docksal.yml file, start the containers, and update. I discarded the temp config changes I made. I will make a separate issue for that.